### PR TITLE
add CMake project handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,15 @@ cmake_minimum_required (VERSION 3.1)
 
 project (qtcsv)
 
+#define names
+set(LIB_MAJOR_VERSION 1)
+set(LIB_MINOR_VERSION 3)
+set(LIB_REVISION_VERSION 1)
+set(LIB_VERSION ${LIB_MAJOR_VERSION}.${LIB_MINOR_VERSION}.${LIB_REVISION_VERSION})
+
 #add additional targets enabling sanitizer on demand
 option(SHARED_LIB "build as shared lib" ON) # ON is the default
+option(STATIC_LIB "build as static lib" OFF) # OFF is the default
 option(BUILD_AND_RUN_TESTS "build and run tests" ON) # ON is the default
 
 #find the Qt packages, delivered by conan
@@ -15,25 +22,31 @@ set(LIBRARY_NAME ${PROJECT_NAME})
 file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.cpp)
 
 if(SHARED_LIB)
-	add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
-else()
-	add_library(${LIBRARY_NAME} STATIC ${SOURCE_FILES})
+	set(LIBRARY_NAME_SHARED ${LIBRARY_NAME})
+	add_library(${LIBRARY_NAME_SHARED} SHARED ${SOURCE_FILES})
+	#include root project folder as private, because the source headers are included with source/*.h
+	target_include_directories(${LIBRARY_NAME_SHARED} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
+	set_target_properties(${LIBRARY_NAME_SHARED} PROPERTIES VERSION ${LIB_VERSION} SOVERSION ${LIB_MAJOR_VERSION}.${LIB_MINOR_VERSION})
+	TARGET_LINK_LIBRARIES(${LIBRARY_NAME_SHARED} PRIVATE Qt5::Core)
 endif(SHARED_LIB)
-set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION 1.3.1 SOVERSION 1.3)
+if(STATIC_LIB)
+	set(LIBRARY_NAME_STATIC ${LIBRARY_NAME}_static)
+	add_library(${LIBRARY_NAME_STATIC} STATIC ${SOURCE_FILES})
+	#include root project folder as private, because the source headers are included with source/*.h
+  target_include_directories(${LIBRARY_NAME_STATIC} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
+	#set static lib name to the same of shared lib
+	set_target_properties(${LIBRARY_NAME_STATIC} PROPERTIES OUTPUT_NAME ${LIBRARY_NAME})
+	TARGET_LINK_LIBRARIES(${LIBRARY_NAME_STATIC} PRIVATE Qt5::Core)
+endif(STATIC_LIB)
 
-#include root project folder as private, because the source headers are included with source/*.h
-target_include_directories(${LIBRARY_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
-
-TARGET_LINK_LIBRARIES(${LIBRARY_NAME} PRIVATE Qt5::Core)
-
-install(TARGETS ${LIBRARY_NAME} EXPORT ${LIBRARY_NAME}Config
+install(TARGETS ${LIBRARY_NAME_SHARED} ${LIBRARY_NAME_STATIC} EXPORT ${LIBRARY_NAME}Config
         LIBRARY DESTINATION lib
 				ARCHIVE DESTINATION lib)
 install(DIRECTORY include DESTINATION .)
 
 #create and install cmake package files
 install(EXPORT ${LIBRARY_NAME}Config DESTINATION share/${LIBRARY_NAME}/cmake)
-export(TARGETS ${LIBRARY_NAME} FILE ${LIBRARY_NAME}Config.cmake)
+export(TARGETS ${LIBRARY_NAME_SHARED} ${LIBRARY_NAME_STATIC} FILE ${LIBRARY_NAME}Config.cmake)
 
 if(BUILD_AND_RUN_TESTS)
 	add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required (VERSION 3.1)
+
+project (qtcsv)
+
+#add additional targets enabling sanitizer on demand
+option(SHARED_LIB "build as shared lib" ON) # ON is the default
+option(BUILD_AND_RUN_TESTS "build and run tests" ON) # ON is the default
+
+#find the Qt packages, delivered by conan
+find_package(Qt5Core REQUIRED)
+
+#define names
+set(LIBRARY_NAME ${PROJECT_NAME})
+
+file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.cpp)
+
+if(SHARED_LIB)
+	add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
+else()
+	add_library(${LIBRARY_NAME} STATIC ${SOURCE_FILES})
+endif(SHARED_LIB)
+set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION 1.3.1 SOVERSION 1.3)
+
+#include root project folder as private, because the source headers are included with source/*.h
+target_include_directories(${LIBRARY_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
+
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME} PRIVATE Qt5::Core)
+
+install(TARGETS ${LIBRARY_NAME} EXPORT ${LIBRARY_NAME}Config
+        LIBRARY DESTINATION lib
+				ARCHIVE DESTINATION lib)
+install(DIRECTORY include DESTINATION .)
+
+#create and install cmake package files
+install(EXPORT ${LIBRARY_NAME}Config DESTINATION share/${LIBRARY_NAME}/cmake)
+export(TARGETS ${LIBRARY_NAME} FILE ${LIBRARY_NAME}Config.cmake)
+
+if(BUILD_AND_RUN_TESTS)
+	add_subdirectory(tests)
+endif(BUILD_AND_RUN_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,16 @@ set(LIB_VERSION ${LIB_MAJOR_VERSION}.${LIB_MINOR_VERSION}.${LIB_REVISION_VERSION
 #add additional targets enabling sanitizer on demand
 option(SHARED_LIB "build as shared lib" ON) # ON is the default
 option(STATIC_LIB "build as static lib" OFF) # OFF is the default
-option(BUILD_AND_RUN_TESTS "build and run tests" ON) # ON is the default
+option(BUILD_TESTS "build tests" ON) # ON is the default
+option(USE_QT4 "builds against Qt4 if true, otherwise builds against Qt5" OFF)# OFF ist the default
 
-#find the Qt packages, delivered by conan
-find_package(Qt5Core REQUIRED)
+if(USE_QT4)
+	find_package(Qt4 REQUIRED)
+	set(QT_CORE_TARGET Qt4::QtGui)
+else()
+	find_package(Qt5Core REQUIRED)
+	set(QT_CORE_TARGET Qt5::Core)
+endif(USE_QT4)
 
 #define names
 set(LIBRARY_NAME ${PROJECT_NAME})
@@ -27,7 +33,7 @@ if(SHARED_LIB)
 	#include root project folder as private, because the source headers are included with source/*.h
 	target_include_directories(${LIBRARY_NAME_SHARED} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
 	set_target_properties(${LIBRARY_NAME_SHARED} PROPERTIES VERSION ${LIB_VERSION} SOVERSION ${LIB_MAJOR_VERSION}.${LIB_MINOR_VERSION})
-	TARGET_LINK_LIBRARIES(${LIBRARY_NAME_SHARED} PRIVATE Qt5::Core)
+	TARGET_LINK_LIBRARIES(${LIBRARY_NAME_SHARED} PRIVATE ${QT_CORE_TARGET})
 endif(SHARED_LIB)
 if(STATIC_LIB)
 	set(LIBRARY_NAME_STATIC ${LIBRARY_NAME}_static)
@@ -36,7 +42,7 @@ if(STATIC_LIB)
   target_include_directories(${LIBRARY_NAME_STATIC} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
 	#set static lib name to the same of shared lib
 	set_target_properties(${LIBRARY_NAME_STATIC} PROPERTIES OUTPUT_NAME ${LIBRARY_NAME})
-	TARGET_LINK_LIBRARIES(${LIBRARY_NAME_STATIC} PRIVATE Qt5::Core)
+	TARGET_LINK_LIBRARIES(${LIBRARY_NAME_STATIC} PRIVATE ${QT_CORE_TARGET})
 endif(STATIC_LIB)
 
 install(TARGETS ${LIBRARY_NAME_SHARED} ${LIBRARY_NAME_STATIC} EXPORT ${LIBRARY_NAME}Config

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.1)
+
+project (qtcsv_tests)
+
+find_package(Qt5Test REQUIRED)
+
+#define names
+set(BINARY_NAME ${PROJECT_NAME})
+
+#Instruct CMake to run moc automatically when needed.
+set(CMAKE_AUTOMOC ON)
+
+#add also the header part to source files. this is necessary for correct automoc
+file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+
+add_executable(${BINARY_NAME} ${SOURCE_FILES} )
+
+TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE Qt5::Test qtcsv)
+
+#provide current project dir for projects header search path
+target_include_directories(${BINARY_NAME} PRIVATE .)
+
+#copy test files after build
+add_custom_command(TARGET ${BINARY_NAME} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data)
+
+#run tests after build; they assume to be runned from top level bin-dir
+add_custom_command(TARGET ${BINARY_NAME} POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND ./tests/${BINARY_NAME})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 
 project (qtcsv_tests)
 
-find_package(Qt5Test REQUIRED)
+if(USE_QT4)
+	find_package(Qt4 REQUIRED)
+	set(QT_TEST_TARGET Qt4::QtTest)
+else()
+	find_package(Qt5Test REQUIRED)
+	set(QT_TEST_TARGET Qt5::Test)
+endif(USE_QT4)
+
 
 #define names
 set(BINARY_NAME ${PROJECT_NAME})
@@ -16,9 +23,9 @@ file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT
 add_executable(${BINARY_NAME} ${SOURCE_FILES} )
 
 if(SHARED_LIB)
-  TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE Qt5::Test qtcsv)
+  TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE ${QT_TEST_TARGET} qtcsv)
 else()
-  TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE Qt5::Test qtcsv_static)
+  TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE ${QT_TEST_TARGET} qtcsv_static)
 endif(SHARED_LIB)
 
 #provide current project dir for projects header search path
@@ -30,4 +37,9 @@ add_custom_command(TARGET ${BINARY_NAME} POST_BUILD
                    ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data)
 
 #run tests after build; they assume to be runned from top level bin-dir
-add_custom_command(TARGET ${BINARY_NAME} POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND ./tests/${BINARY_NAME})
+# add_custom_command(TARGET ${BINARY_NAME} POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND ./tests/${BINARY_NAME})
+
+#install the test environment
+install(TARGETS ${BINARY_NAME}
+        RUNTIME DESTINATION bin/tests)
+install(DIRECTORY data DESTINATION bin/tests/)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,11 @@ file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT
 
 add_executable(${BINARY_NAME} ${SOURCE_FILES} )
 
-TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE Qt5::Test qtcsv)
+if(SHARED_LIB)
+  TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE Qt5::Test qtcsv)
+else()
+  TARGET_LINK_LIBRARIES(${BINARY_NAME} PRIVATE Qt5::Test qtcsv_static)
+endif(SHARED_LIB)
 
 #provide current project dir for projects header search path
 target_include_directories(${BINARY_NAME} PRIVATE .)


### PR DESCRIPTION
I want to create a conan.io package of your project. It easier to handle this, when the project builds with cmake. Therefore i implemented cmake project handling. I tried to adopt as most as possible of your qmake setup. Including your lib-versioning and symlinking.

You can test with example build:
```
git clone https://github.com/cguentherTUChemnitz/qtcsv
cd ./qtcsv
mkdir build && cd ./build
cmake ..
make

```
I added two options, to handle the shared or static lib compilations, as well as the testing as a post-build step. This can be switched by:

`cmake .. -DSHARED_LIB=OFF -DBUILD_AND_RUN_TESTS=OFF`

I added also the installations commands. The default installation prefix is /usr/local for cmake. The installation can be started with:

`make install`