### PR TITLE
improved handling of QTCSVSHARED_EXPORT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ add_custom_target(show_all_files_in_${PROJECT_NAME} SOURCES ${QTCSV_ALL_FILES})
 
 if(STATIC_LIB)
     add_library(${LIBRARY_NAME} STATIC ${SOURCE_FILES})
+    #propogate the QTCSV_STATIC_LIB define for all qtcsv consuming stuff
+    #necessary for correct QTCSVSHARED_EXPORT handling, espacially for windows (cross compilation) builds
+    target_compile_definitions(${LIBRARY_NAME} PUBLIC -DQTCSV_STATIC_LIB)
 else()
     add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
     set_target_properties(${LIBRARY_NAME} PROPERTIES
@@ -46,7 +49,8 @@ else()
         SOVERSION ${LIB_MAJOR_VERSION})
 endif(STATIC_LIB)
 
-add_definitions(-DQTCSV_LIBRARY)
+#use the QTCSV_LIBRARY define only for qtcsv build time to use export statements instead of import statements
+target_compile_definitions(${LIBRARY_NAME} PRIVATE -DQTCSV_LIBRARY)
 
 # include root project folder as private, because the source headers are included with source/*.h
 target_include_directories(${LIBRARY_NAME}
@@ -55,7 +59,7 @@ target_include_directories(${LIBRARY_NAME}
 # set compiler flags for the library target
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(${LIBRARY_NAME} PRIVATE -Wall -Werror -Wformat=2 -Wuninitialized
-        -Winit-self -Wmissing-include-dirs -Wswitch-enum -Wundef
+        -Winit-self -Wswitch-enum -Wundef
         -Wpointer-arith -Wdisabled-optimization -Wcast-align -Wcast-qual)
 endif()
 

--- a/include/qtcsv/qtcsv_global.h
+++ b/include/qtcsv/qtcsv_global.h
@@ -3,10 +3,14 @@
 
 #include <QtCore/qglobal.h>
 
-#if defined(QTCSV_LIBRARY)
-#  define QTCSVSHARED_EXPORT Q_DECL_EXPORT
+#ifdef QTCSV_STATIC_LIB
+#  define QTCSVSHARED_EXPORT
 #else
-#  define QTCSVSHARED_EXPORT Q_DECL_IMPORT
+#  if defined(QTCSV_LIBRARY)
+#    define QTCSVSHARED_EXPORT Q_DECL_EXPORT
+#  else
+#    define QTCSVSHARED_EXPORT Q_DECL_IMPORT
+#  endif
 #endif
 
 #endif // QTCSV_GLOBAL_H


### PR DESCRIPTION
- do not pollute the global cmake def space --> add_definitions replaced by target_compile_definitions
- QTCSV_LIBRARY is only a private compile define, because it should be used only by the lib itself and no qtcsv consuming target should use the define
- an additional public QTCSV_STATIC_LIB define is introduced to make sure that QTCSVSHARED_EXPORT is empty for static lib builds
--> those changes makes it possible to cross-compile from linux to windows with mingw shared and static version

-Wmissing-include-dirs is removed, because it breaks in some conditions my build, the conditions are:
rebuilding the lib statically without tests --> automoc is executed, but produces nothing else then not existing include dir entries --> handling this warning as error, breaks the build