### PR TITLE
added pri for importing into an existing QT project

### DIFF
--- a/qtcsv.pri
+++ b/qtcsv.pri
@@ -1,0 +1,24 @@
+ 
+QT -= gui
+
+DEFINES +=  QTCSV_MAKE_LIB
+
+INCLUDEPATH += $$PWD/include \
+               $$PWD
+SOURCES += \
+    $$PWD/sources/writer.cpp \
+    $$PWD/sources/variantdata.cpp \
+    $$PWD/sources/stringdata.cpp \
+    $$PWD/sources/reader.cpp \
+    $$PWD/sources/contentiterator.cpp
+
+HEADERS += \
+    $$PWD/include/qtcsv/qtcsv_global.h \
+    $$PWD/include/qtcsv/writer.h \
+    $$PWD/include/qtcsv/variantdata.h \
+    $$PWD/include/qtcsv/stringdata.h \
+    $$PWD/include/qtcsv/reader.h \
+    $$PWD/include/qtcsv/abstractdata.h \
+    $$PWD/sources/filechecker.h \
+    $$PWD/sources/contentiterator.h \
+    $$PWD/sources/symbols.h


### PR DESCRIPTION
This pri configuration should allow this project to be easily imported into an existing QT project. 

example:
```
include(3rdpart/qtcsv/qtcsv.pri)
```