### PR TITLE
Fix up project files

### DIFF
--- a/qtcsv.pri
+++ b/qtcsv.pri
@@ -1,7 +1,7 @@
- 
-QT -= gui
+CONFIG *= qt
+QT *= core
 
-DEFINES +=  QTCSV_MAKE_LIB
+!contains(DEFINES, QTCSV_LIBRARY): DEFINES += QTCSV_MAKE_LIB
 
 INCLUDEPATH += $$PWD/include \
                $$PWD

--- a/qtcsv.pro
+++ b/qtcsv.pro
@@ -1,4 +1,4 @@
-QT -= gui
+QT = core
 TARGET = qtcsv
 TEMPLATE = lib
 VERSION = 1.5.0
@@ -16,33 +16,20 @@ win32:TARGET_EXT = .dll
 }
 
 DEFINES += QTCSV_LIBRARY
-INCLUDEPATH += $$PWD/include/
+
+include(qtcsv.pri)
 
 # Uncomment this settings if you want to manually set destination directory for
 # compiled library
 #CONFIG(release, debug|release): DESTDIR = $$PWD
 #CONFIG(debug, debug|release): DESTDIR = $$PWD
 
-SOURCES += \
-    sources/writer.cpp \
-    sources/variantdata.cpp \
-    sources/stringdata.cpp \
-    sources/reader.cpp \
-    sources/contentiterator.cpp
-
-HEADERS += \
-    include/qtcsv/qtcsv_global.h \
-    include/qtcsv/writer.h \
-    include/qtcsv/variantdata.h \
-    include/qtcsv/stringdata.h \
-    include/qtcsv/reader.h \
-    include/qtcsv/abstractdata.h \
-    sources/filechecker.h \
-    sources/contentiterator.h \
-    sources/symbols.h
-
 DISTFILES += \
     CMakeLists.txt
+
+OTHER_FILES += \
+    appveyor.yml \
+    .travis.yml
 
 message(=== Configuration of qtcsv ===)
 message(Qt version: $$[QT_VERSION])

--- a/qtcsv.pro
+++ b/qtcsv.pro
@@ -15,6 +15,7 @@ win32:TARGET_EXT = .dll
             -Wdisabled-optimization -Wcast-align -Wcast-qual
 }
 
+CONFIG(staticlib): DEFINES += QTCSV_STATIC_LIB
 DEFINES += QTCSV_LIBRARY
 
 include(qtcsv.pri)


### PR DESCRIPTION
Add missing QTCSV_STATIC_LIB define to qmake project. Don't modify QT modules in the pri file. Use the pri file in the pro file so as not to repeat the file list. Add the CI files to the project so that they're editable from the IDE.