### PR TITLE
New c make lists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,6 @@ install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake DESTINATION
 configure_file(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig)
 
-#if(BUILD_TESTS)
-#    add_subdirectory(tests)
-#endif(BUILD_TESTS)
+if(BUILD_TESTS)
+    add_subdirectory(tests)
+endif(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,49 +7,60 @@ option(STATIC_LIB "build as static lib if ON, otherwise build shared lib" OFF)
 option(USE_QT4 "builds against Qt4 if ON, otherwise builds against Qt5" OFF)
 option(BUILD_TESTS "build tests" ON)
 
+# settings
+set(BUILD_LIBRARY_DEFINITION QTCSV_LIBRARY)
+
 # find qt package
 if(USE_QT4)
-    find_package(Qt4 REQUIRED)
-    set(QT_CORE_TARGET Qt4::QtCore)
+    find_package(Qt4Core REQUIRED)
+    find_package(Qt4Network REQUIRED)
+    set(QT_TARGET Qt4::QtCore Qt4::Network)
 else()
     # if cmake failed to find Qt5Core configuration file, set path manually:
     #list(APPEND CMAKE_PREFIX_PATH "/path/to/Qt/lib/cmake/Qt5Core/")
 
     find_package(Qt5Core REQUIRED)
-    set(QT_CORE_TARGET Qt5::Core)
+    find_package(Qt5Network REQUIRED)
+    set(QT_TARGET Qt5::Core Qt5::Network)
 endif(USE_QT4)
+
+set(CMAKE_DEBUG_POSTFIX .debug)
 
 # instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
 
 # set list of source files
-file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.cpp)
+file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.c ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.cxx ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.c++)
+#message("Source files:" ${SOURCE_FILES})
+
+file(GLOB_RECURSE HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Include/*.h)
+#message("HEADER_FILES: " ${HEADER_FILES})
 
 # Show all files in QtCreator. Starting with CMake 3.7 server-mode is used
 # and QtCreator will show the files properly in an extra <Headers> section.
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
-    file(GLOB_RECURSE QTCSV_ALL_FILES "*")
-    add_custom_target(show_all_files_in_${PROJECT_NAME} SOURCES ${QTCSV_ALL_FILES})
+    file(GLOB_RECURSE ALL_FILES "*")
+    add_custom_target(show_all_files_in_${PROJECT_NAME} SOURCES ${ALL_FILES})
 endif()
 
 if(STATIC_LIB)
-    add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES})
-    #propogate the QTCSV_STATIC_LIB define for all qtcsv consuming stuff
-    #necessary for correct QTCSVSHARED_EXPORT handling, espacially for windows (cross compilation) builds
-    target_compile_definitions(${PROJECT_NAME} PUBLIC -DQTCSV_STATIC_LIB)
+    add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES} ${HEADER_FILES})
+    #propogate the STATIC_LIB define for all consuming stuff
+    #necessary for correct ${PROJECT_NAME}SHARED_EXPORT handling, espacially for windows (cross compilation) builds
+    target_compile_definitions(${PROJECT_NAME} PUBLIC -D${PROJECT_NAME}_STATIC_LIB)
 else()
-    add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+    add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${HEADER_FILES})
     set_target_properties(${PROJECT_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR})
 endif(STATIC_LIB)
 
-#use the QTCSV_LIBRARY define only for qtcsv build time to use export statements instead of import statements
-target_compile_definitions(${PROJECT_NAME} PRIVATE -DQTCSV_LIBRARY)
+target_compile_definitions(${PROJECT_NAME} PRIVATE -D${BUILD_LIBRARY_DEFINITION})
 
 # include root project folder as private, because the source headers are included with source/*.h
 target_include_directories(${PROJECT_NAME}
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE .)
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include/${PROJECT_NAME}> $<INSTALL_INTERFACE:include> PRIVATE .)
 
 # set compiler flags for the library target
 if (CMAKE_COMPILER_IS_GNUCXX)
@@ -58,19 +69,34 @@ if (CMAKE_COMPILER_IS_GNUCXX)
         -Wpointer-arith -Wdisabled-optimization -Wcast-align -Wcast-qual)
 endif()
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_CORE_TARGET})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_TARGET})
 
+target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS})
+
+# Install
+include(GNUInstallDirs)
+
+# Install headers
+install(DIRECTORY Include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Install exe, library, and archive files - we can't install headers here because we can have directory structure (not just flat subdir with headers)
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/${CMAKE_LIBRARY_ARCHITECTURE}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE})
 
-install(DIRECTORY include DESTINATION .)
+# Create and install Cmake Config file
+install(EXPORT ${PROJECT_NAME}Config DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/cmake/${PROJECT_NAME})
 
-# create and install cmake package files
-install(EXPORT ${PROJECT_NAME}Config DESTINATION share/${PROJECT_NAME}/cmake)
-export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_NAME}Config.cmake)
+# Create and install Cmake version file
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file( ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/cmake/${PROJECT_NAME})
 
-if(BUILD_TESTS)
-    add_subdirectory(tests)
-endif(BUILD_TESTS)
+# Create and install pc file
+configure_file(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig)
+
+#if(BUILD_TESTS)
+#    add_subdirectory(tests)
+#endif(BUILD_TESTS)

--- a/qtcsv.pc.in
+++ b/qtcsv.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
At first: Thank you! I am highly inspired by your original CMakeLists.txt. As you probably know Qt will switch to cmake and drop qmake with advent of Qt6. Now I am in process switch to cmake all my C++ projects. Now I switched all my libraries (and 3rdparty libraries). As I said: I begin with yours CMakeLists.txt but now I made also few changes most notable are:
* multiarch: library should be installed in: /usr/local/lib/x86_64-linux-gnu not just /usr/local/lib - in that way works Qt and Kde.
* generation qtcsvConfig.cmake (it is recommended way to include and link to other cmake projects)
* generation qtcsvConfigVersion.cmake (not sure what is for - but it is easy to generate - so why not?)
* generation qtcsv.pc (it makes your library easy to include and link to Make and AutoTols projects)