### PR TITLE
Issue 59: use QElapsedTimer instead of QTime in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,20 +86,35 @@ matrix:
     dist: xenial
     compiler: gcc
     env:
-     - QT_BASE=511
+     - QT_BASE=511 USE_CMAKE=true
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-     - QT_BASE=511 USE_CMAKE=true
+     - QT_BASE=512 USE_CMAKE=true
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+     - QT_BASE=513 USE_CMAKE=true
   - os: osx
     compiler: clang
     env:
-     - QT_BASE=511
+     - QT_BASE=513
   - os: osx
     compiler: clang
     env:
-     - QT_BASE=511 USE_CMAKE=true
+     - QT_BASE=513 USE_CMAKE=true
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+     - QT_BASE=514
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+     - QT_BASE=514 USE_CMAKE=true
 
 before_install:
   - if [[ "$QT_BASE" = "48" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt487-trusty -y; fi
@@ -111,9 +126,12 @@ before_install:
   - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt563-trusty -y; fi
   - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
   - if [ "$QT_BASE" = "58" ]; then sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y; fi
-  - if [ "$QT_BASE" = "59" ]; then sudo add-apt-repository ppa:beineri/opt-qt595-trusty -y; fi
+  - if [ "$QT_BASE" = "59" ]; then sudo add-apt-repository ppa:beineri/opt-qt597-trusty -y; fi
   - if [ "$QT_BASE" = "510" ]; then sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y; fi
-  - if [[ "$QT_BASE" = "511" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt-5.11.2-xenial -y; fi
+  - if [ "$QT_BASE" = "511" ]; then sudo add-apt-repository ppa:beineri/opt-qt-5.11.3-xenial -y; fi
+  - if [ "$QT_BASE" = "512" ]; then sudo add-apt-repository ppa:beineri/opt-qt-5.12.8-xenial -y; fi
+  - if [[ "$QT_BASE" = "513" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt-5.13.2-xenial -y; fi
+  - if [ "$QT_BASE" = "514" ]; then sudo add-apt-repository ppa:beineri/opt-qt-5.14.2-xenial -y; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get update -qq;
     else
@@ -141,9 +159,11 @@ install:
   - if [ "$QT_BASE" = "58" ]; then sudo apt-get install -qq qt58base; source /opt/qt58/bin/qt58-env.sh; fi
   - if [ "$QT_BASE" = "59" ]; then sudo apt-get install -qq qt59base; source /opt/qt59/bin/qt59-env.sh; fi
   - if [ "$QT_BASE" = "510" ]; then sudo apt-get install -qq qt510base; source /opt/qt510/bin/qt510-env.sh; fi
-  - if [ "$QT_BASE" = "511" ]; then
+  - if [ "$QT_BASE" = "511" ]; then sudo apt-get install -qq qt511base; source /opt/qt511/bin/qt511-env.sh; fi
+  - if [ "$QT_BASE" = "512" ]; then sudo apt-get install -qq qt512base; source /opt/qt512/bin/qt512-env.sh; fi
+  - if [ "$QT_BASE" = "513" ]; then
       if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        sudo apt-get install -qq qt511base; source /opt/qt511/bin/qt511-env.sh;
+        sudo apt-get install -qq qt511base; source /opt/qt513/bin/qt513-env.sh;
       else
         brew install qt;
         brew link --force qt;
@@ -152,6 +172,7 @@ install:
         echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> ~/.bash_profile;
       fi
     fi
+  - if [ "$QT_BASE" = "514" ]; then sudo apt-get install -qq qt514base; source /opt/qt514/bin/qt514-env.sh; fi
 
 script:
   # build library and tests, install library

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ install:
   - if [ "$QT_BASE" = "512" ]; then sudo apt-get install -qq qt512base; source /opt/qt512/bin/qt512-env.sh; fi
   - if [ "$QT_BASE" = "513" ]; then
       if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        sudo apt-get install -qq qt511base; source /opt/qt513/bin/qt513-env.sh;
+        sudo apt-get install -qq qt513base; source /opt/qt513/bin/qt513-env.sh;
       else
         brew install qt;
         brew link --force qt;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,18 @@ environment:
     MINGW: C:\Qt\Tools\mingw530_32
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     use_cmake: "false"
+  - QT5: C:\Qt\5.12\mingw73_32
+    MINGW: C:\Qt\Tools\mingw730_32
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    use_cmake: "false"
+  - QT5: C:\Qt\5.13\mingw73_32
+    MINGW: C:\Qt\Tools\mingw730_32
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    use_cmake: "false"
+  - QT5: C:\Qt\5.14\mingw73_32
+    MINGW: C:\Qt\Tools\mingw730_32
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    use_cmake: "false"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,10 +52,6 @@ environment:
     MINGW: C:\Qt\Tools\mingw730_32
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     use_cmake: "false"
-  - QT5: C:\Qt\5.14.2\mingw73_32
-    MINGW: C:\Qt\Tools\mingw730_32
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    use_cmake: "false"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ environment:
     MINGW: C:\Qt\Tools\mingw730_32
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     use_cmake: "false"
-  - QT5: C:\Qt\5.14\mingw73_32
+  - QT5: C:\Qt\5.14.2\mingw73_32
     MINGW: C:\Qt\Tools\mingw730_32
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     use_cmake: "false"

--- a/tests/testreader.cpp
+++ b/tests/testreader.cpp
@@ -2,7 +2,7 @@
 
 #include <QDir>
 #include <QFile>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include "qtcsv/reader.h"
 #include "qtcsv/stringdata.h"
@@ -379,7 +379,7 @@ void TestReader::testReadFileWorldCitiesPop()
         return;
     }
 
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
     QList<QStringList> data = QtCSV::Reader::readToList(path, ",", "\"");
     qDebug() << "Elapsed time:" << timer.elapsed() << "ms";

--- a/tests/testwriter.cpp
+++ b/tests/testwriter.cpp
@@ -4,7 +4,7 @@
 
 #include <QDir>
 #include <QFile>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QDebug>
 
 #include "qtcsv/writer.h"
@@ -311,7 +311,7 @@ void TestWriter::testWriteDifferentDataAmount()
     int rowsNumber = 10;
     int rowsMultiplier  = 2;
     int rowCycles = 2;
-    QTime time;
+    QElapsedTimer time;
     for ( int rc = 0; rc < rowCycles; ++rc )
     {
         int symbolsNumber = 10;


### PR DESCRIPTION
- use QElapsedTimer instead of QTime in test files
- add new builds with Qt 5.12 - 5.14 on linux and 5.12 - 5.13 on Windows