### PR TITLE
Change qrand() , use QRandomGenerator instead in QT > 5.10.0

### DIFF
--- a/sources/writer.cpp
+++ b/sources/writer.cpp
@@ -7,6 +7,10 @@
 #include <QTextStream>
 #include <QCoreApplication>
 #include <QDebug>
+#include <QtGlobal>
+#if QT_VERSION >= 0x050A00
+#include <QRandomGenerator>
+#endif
 
 #include "include/qtcsv/abstractdata.h"
 #include "sources/filechecker.h"
@@ -180,7 +184,11 @@ QString WriterPrivate::getTempFileName()
 
     for (int counter = 0; counter < std::numeric_limits<int>::max(); ++counter)
     {
-        QString name = nameTemplate.arg(QString::number(qrand()));
+#if QT_VERSION >= 0x050A00
+         QString name = nameTemplate.arg(QString::number(QRandomGenerator::global()->generate()));
+#else
+         QString name = nameTemplate.arg(QString::number(QString::number(qrand()));
+#endif
         if ( false == QFile::exists(name) )
         {
             return name;


### PR DESCRIPTION
When trying to build with Cmake on my system : 
```
Qt 5.15.0 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 10.1.0) on "xcb" 
OS: Arch Linux [linux version 5.4.49-1-lts]
```
The error message : 
```

/home/akr/qtcsv/sources/writer.cpp:183:63: error: ‘int qrand()’ is deprecated: use QRandomGenerator instead [-Werror=deprecated-declarations]
  183 |         QString name = nameTemplate.arg(QString::number(qrand()));
      |                  
```                       
In QT documentation : 

**Note: This function is deprecated. In new applications, use QRandomGenerator instead.** **_in QT > 5.10.0_** 

https://doc.qt.io/qt-5/qtglobal-obsolete.html#qrand 

After changing qrand() it was built without any problems .

