### PR TITLE
Add support for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,16 @@ project (qtcsv VERSION 1.5.0 LANGUAGES CXX)
 # set options
 option(STATIC_LIB "build as static lib if ON, otherwise build shared lib" OFF)
 option(USE_QT4 "builds against Qt4 if ON, otherwise builds against Qt5" OFF)
+option(USE_QT6 "builds against Qt6 if ON, otherwise builds against Qt5" OFF)
 option(BUILD_TESTS "build tests" ON)
 
 # find qt package
 if(USE_QT4)
     find_package(Qt4 REQUIRED)
     set(QT_CORE_TARGET Qt4::QtCore)
+elseif(USE_QT6)
+    find_package(Qt6 COMPONENTS Core Core5Compat REQUIRED)
+    set(QT_CORE_TARGET Qt6::Core Qt6::Core5Compat)
 else()
     # if cmake failed to find Qt5Core configuration file, set path manually:
     #list(APPEND CMAKE_PREFIX_PATH "/path/to/Qt/lib/cmake/Qt5Core/")

--- a/include/qtcsv/abstractdata.h
+++ b/include/qtcsv/abstractdata.h
@@ -3,7 +3,11 @@
 
 #include "qtcsv_global.h"
 
+#if QT_VERSION >= 0x060000
+using QStringList = QList<QString>;
+#else
 class QStringList;
+#endif
 
 namespace QtCSV
 {

--- a/include/qtcsv/reader.h
+++ b/include/qtcsv/reader.h
@@ -7,7 +7,11 @@
 #include "qtcsv/qtcsv_global.h"
 
 class QIODevice;
+#if QT_VERSION >= 0x060000
+using QStringList = QList<QString>;
+#else
 class QStringList;
+#endif
 
 namespace QtCSV
 {

--- a/include/qtcsv/reader.h
+++ b/include/qtcsv/reader.h
@@ -2,14 +2,15 @@
 #define QTCSVREADER_H
 
 #include <QList>
-#include <QTextCodec>
 
 #include "qtcsv/qtcsv_global.h"
 
 class QIODevice;
 #if QT_VERSION >= 0x060000
+#include <QtCore5Compat/QTextCodec>
 using QStringList = QList<QString>;
 #else
+#include <QTextCodec>
 class QStringList;
 #endif
 
@@ -67,14 +68,24 @@ namespace QtCSV
         static QList<QStringList> readToList(const QString& filePath,
                         const QString& separator = QString(","),
                         const QString& textDelimiter = QString("\""),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
 
         // Read csv-formatted data from IO Device and save it
         // as strings to QList<QStringList>
         static QList<QStringList> readToList(QIODevice& ioDevice,
                         const QString& separator = QString(","),
                         const QString& textDelimiter = QString("\""),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
 
         // Read csv-file and save it's data to AbstractData-based container
         // class
@@ -82,7 +93,12 @@ namespace QtCSV
                         AbstractData& data,
                         const QString& separator = QString(","),
                         const QString& textDelimiter = QString("\""),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
 
         // Read csv-formatted data from IO Device and save it
         // to AbstractData-based container class
@@ -90,21 +106,36 @@ namespace QtCSV
                         AbstractData& data,
                         const QString& separator = QString(","),
                         const QString& textDelimiter = QString("\""),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
 
         // Read csv-file and process it line-by-line
         static bool readToProcessor(const QString& filePath,
                         AbstractProcessor& processor,
                         const QString& separator = QString(","),
                         const QString& textDelimiter = QString("\""),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
 
         // Read csv-formatted data from IO Device and process it line-by-line
         static bool readToProcessor(QIODevice& ioDevice,
                         AbstractProcessor& processor,
                         const QString& separator = QString(","),
                         const QString& textDelimiter = QString("\""),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
     };
 }
 

--- a/include/qtcsv/stringdata.h
+++ b/include/qtcsv/stringdata.h
@@ -4,8 +4,12 @@
 #include "qtcsv/qtcsv_global.h"
 #include "qtcsv/abstractdata.h"
 
+#if QT_VERSION >= 0x060000
+using QStringList = QList<QString>;
+#else
 class QString;
 class QStringList;
+#endif
 
 namespace QtCSV
 {

--- a/include/qtcsv/variantdata.h
+++ b/include/qtcsv/variantdata.h
@@ -7,7 +7,11 @@
 #include "qtcsv/qtcsv_global.h"
 
 class QVariant;
+#if QT_VERSION >= 0x060000
+using QStringList = QList<QString>;
+#else
 class QStringList;
+#endif
 
 namespace QtCSV
 {

--- a/include/qtcsv/writer.h
+++ b/include/qtcsv/writer.h
@@ -3,7 +3,12 @@
 
 #include <QString>
 #include <QStringList>
+#if QT_VERSION >= 0x060000
+#include <QStringConverter>
+#include <QtCore5Compat/QTextCodec>
+#else
 #include <QTextCodec>
+#endif
 
 #include "qtcsv/qtcsv_global.h"
 
@@ -41,7 +46,12 @@ namespace QtCSV
                         const WriteMode& mode = REWRITE,
                         const QStringList& header = QStringList(),
                         const QStringList& footer = QStringList(),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                        QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
 
         // Write data to IO Device
         static bool write(QIODevice& ioDevice,
@@ -50,7 +60,12 @@ namespace QtCSV
                         const QString& textDelimiter = QString("\""),
                         const QStringList& header = QStringList(),
                         const QStringList& footer = QStringList(),
-                        QTextCodec* codec = QTextCodec::codecForName("UTF-8"));
+#if QT_VERSION >= 0x060000
+                          QStringConverter::Encoding codec = QStringConverter::Utf8
+#else
+                          QTextCodec* codec = QTextCodec::codecForName("UTF-8")
+#endif
+                );
     };
 }
 

--- a/sources/contentiterator.h
+++ b/sources/contentiterator.h
@@ -1,8 +1,14 @@
 #ifndef QTCSVCONTENTITERATOR_H
 #define QTCSVCONTENTITERATOR_H
 
+#include <QtGlobal>
+
+#if QT_VERSION >= 0x060000
+using QStringList = QList<QString>;
+#else
 class QString;
 class QStringList;
+#endif
 
 namespace QtCSV
 {

--- a/sources/reader.cpp
+++ b/sources/reader.cpp
@@ -48,7 +48,12 @@ public:
                      Reader::AbstractProcessor& processor,
                      const QString& separator,
                      const QString& textDelimiter,
-                     QTextCodec* codec);
+#if QT_VERSION >= 0x060000
+                     QStringConverter::Encoding codec
+#else
+                     QTextCodec* codec
+#endif
+                     );
 
 
 private:
@@ -92,7 +97,12 @@ bool ReaderPrivate::read(QIODevice& ioDevice,
                          Reader::AbstractProcessor& processor,
                          const QString& separator,
                          const QString& textDelimiter,
-                         QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                         QStringConverter::Encoding codec
+#else
+                         QTextCodec* codec
+#endif
+                         )
 {
     if ( false == checkParams(separator) )
     {
@@ -108,7 +118,11 @@ bool ReaderPrivate::read(QIODevice& ioDevice,
     }
 
     QTextStream stream(&ioDevice);
+#if QT_VERSION >= 0x060000
+    stream.setEncoding(codec);
+#else
     stream.setCodec(codec);
+#endif
 
     // This list will contain elements of the row if its elements
     // are located on several lines
@@ -573,7 +587,12 @@ public:
 QList<QStringList> Reader::readToList(const QString& filePath,
                                       const QString& separator,
                                       const QString& textDelimiter,
-                                      QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                                      QStringConverter::Encoding codec
+#else
+                                      QTextCodec* codec
+#endif
+                                      )
 {
     QFile file;
     if (false == openFile(filePath, file))
@@ -589,7 +608,12 @@ QList<QStringList> Reader::readToList(const QString& filePath,
 QList<QStringList> Reader::readToList(QIODevice &ioDevice,
                                       const QString &separator,
                                       const QString &textDelimiter,
-                                      QTextCodec *codec)
+#if QT_VERSION >= 0x060000
+                                      QStringConverter::Encoding codec
+#else
+                                      QTextCodec *codec
+#endif
+                                      )
 {
     ReadToListProcessor processor;
     ReaderPrivate::read(ioDevice, processor, separator, textDelimiter, codec);
@@ -609,7 +633,12 @@ bool Reader::readToData(const QString& filePath,
                         AbstractData& data,
                         const QString& separator,
                         const QString& textDelimiter,
-                        QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec
+#else
+                        QTextCodec* codec
+#endif
+                        )
 {
     QFile file;
     if (false == openFile(filePath, file))
@@ -626,7 +655,12 @@ bool Reader::readToData(QIODevice& ioDevice,
                         AbstractData& data,
                         const QString& separator,
                         const QString& textDelimiter,
-                        QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                        QStringConverter::Encoding codec
+#else
+                        QTextCodec* codec
+#endif
+                        )
 {
     ReadToListProcessor processor;
     if (false == ReaderPrivate::read(
@@ -657,7 +691,12 @@ bool Reader::readToProcessor(const QString& filePath,
                              Reader::AbstractProcessor& processor,
                              const QString& separator,
                              const QString& textDelimiter,
-                             QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                             QStringConverter::Encoding codec
+#else
+                             QTextCodec* codec
+#endif
+                             )
 {
     QFile file;
     if (false == openFile(filePath, file))
@@ -673,7 +712,12 @@ bool Reader::readToProcessor(QIODevice& ioDevice,
                              Reader::AbstractProcessor& processor,
                              const QString& separator,
                              const QString& textDelimiter,
-                             QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                             QStringConverter::Encoding codec
+#else
+                             QTextCodec* codec
+#endif
+                             )
 {
     return ReaderPrivate::read(
                 ioDevice, processor, separator, textDelimiter, codec);

--- a/sources/reader.cpp
+++ b/sources/reader.cpp
@@ -389,11 +389,19 @@ int ReaderPrivate::findMiddleElementPositioin(const QString& str,
         int numOfDelimiters = 0;
         for (int pos = elemEndPos; startPos <= pos; --pos, ++numOfDelimiters)
         {
+#if QT_VERSION >= 0x060000
+            auto strRef = str.mid(pos, txtDelim.size());
+            if (QString::compare(strRef, txtDelim) != 0)
+            {
+                break;
+            }
+#else
             QStringRef strRef = str.midRef(pos, txtDelim.size());
             if (QStringRef::compare(strRef, txtDelim) != 0)
             {
                 break;
             }
+#endif
         }
 
         // If we have odd number of delimiter symbols that stand together,
@@ -451,11 +459,19 @@ bool ReaderPrivate::isElementLast(const QString& str,
     int numOfDelimiters = 0;
     for (int pos = str.size() - 1; startPos <= pos; --pos, ++numOfDelimiters)
     {
+#if QT_VERSION >= 0x060000
+        auto strRef = str.mid(pos, txtDelim.size());
+        if (QString::compare(strRef, txtDelim) != 0)
+        {
+            break;
+        }
+#else
         QStringRef strRef = str.midRef(pos, txtDelim.size());
         if (QStringRef::compare(strRef, txtDelim) != 0)
         {
             break;
         }
+#endif
     }
 
     // If we have odd number of delimiter symbols that stand together,

--- a/sources/writer.cpp
+++ b/sources/writer.cpp
@@ -42,17 +42,32 @@ public:
     // Append information to the file
     static bool appendToFile(const QString& filePath,
                              ContentIterator& content,
-                             QTextCodec* codec);
+#if QT_VERSION >= 0x060000
+                             QStringConverter::Encoding codec
+#else
+                             QTextCodec* codec
+#endif
+                             );
 
     // Overwrite file with new information
     static bool overwriteFile(const QString& filePath,
                               ContentIterator& content,
-                              QTextCodec* codec);
+#if QT_VERSION >= 0x060000
+                              QStringConverter::Encoding codec
+#else
+                              QTextCodec* codec
+#endif
+                              );
 
     // Write to IO Device
     static bool writeToIODevice(QIODevice& ioDevice,
                                 ContentIterator& content,
-                                QTextCodec* codec);
+#if QT_VERSION >= 0x060000
+                                QStringConverter::Encoding codec
+#else
+                                QTextCodec* codec
+#endif
+                                );
 
     // Create unique name for the temporary file
     static QString getTempFileName();
@@ -67,7 +82,12 @@ public:
 // - bool - True if data was appended to the file, otherwise False
 bool WriterPrivate::appendToFile(const QString& filePath,
                                  ContentIterator& content,
-                                 QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                                 QStringConverter::Encoding codec
+#else
+                                 QTextCodec* codec
+#endif
+                                 )
 {
     if ( filePath.isEmpty() || content.isEmpty() )
     {
@@ -98,7 +118,12 @@ bool WriterPrivate::appendToFile(const QString& filePath,
 // - bool - True if file was overwritten with new data, otherwise False
 bool WriterPrivate::overwriteFile(const QString& filePath,
                                   ContentIterator& content,
-                                  QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                                  QStringConverter::Encoding codec
+#else
+                                  QTextCodec* codec
+#endif
+                                  )
 {
     // Create path to the unique temporary file
     QString tempFileName = getTempFileName();
@@ -145,7 +170,12 @@ bool WriterPrivate::overwriteFile(const QString& filePath,
 // - bool - True if data could be written to the IO Device
 bool WriterPrivate::writeToIODevice(QIODevice& ioDevice,
                                     ContentIterator& content,
-                                    QTextCodec* codec) {
+#if QT_VERSION >= 0x060000
+                                    QStringConverter::Encoding codec
+#else
+                                    QTextCodec* codec
+#endif
+                                    ) {
     if ( content.isEmpty() )
     {
         qDebug() << __FUNCTION__ << "Error - invalid arguments";
@@ -161,7 +191,11 @@ bool WriterPrivate::writeToIODevice(QIODevice& ioDevice,
     }
 
     QTextStream stream(&ioDevice);
+#if QT_VERSION >= 0x060000
+    stream.setEncoding(codec);
+#else
     stream.setCodec(codec);
+#endif
     while( content.hasNext() )
     {
         stream << content.getNext();
@@ -221,7 +255,12 @@ bool Writer::write(const QString& filePath,
                    const WriteMode& mode,
                    const QStringList& header,
                    const QStringList& footer,
-                   QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                   QStringConverter::Encoding codec
+#else
+                   QTextCodec* codec
+#endif
+                   )
 {
     if ( filePath.isEmpty() )
     {
@@ -277,7 +316,12 @@ bool Writer::write(QIODevice& ioDevice,
                    const QString& textDelimiter,
                    const QStringList& header,
                    const QStringList& footer,
-                   QTextCodec* codec)
+#if QT_VERSION >= 0x060000
+                   QStringConverter::Encoding codec
+#else
+                   QTextCodec* codec
+#endif
+                   )
 {
     if ( data.isEmpty() )
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 if(USE_QT4)
     find_package(Qt4 REQUIRED)
     set(QT_TEST_TARGET Qt4::QtTest)
+elseif(USE_QT6)
+    find_package(Qt6 COMPONENTS Test REQUIRED)
+    set(QT_TEST_TARGET Qt6::Test)
 else()
     # if cmake failed to find Qt5Test configuration file, set path manually:
     #list(APPEND CMAKE_PREFIX_PATH "/path/to/Qt/lib/cmake/Qt5Test/")


### PR DESCRIPTION
Tested on macOS 11.2. Running tests/qtcsv_tests gives a malloc corruption:

qtcsv_tests(29792,0x1076c0e00) malloc: Region cookie corrupted for region 0x7ff341c00000 (value is 0)[0x7ff341c0407c]
qtcsv_tests(29792,0x1076c0e00) malloc: *** set a breakpoint in malloc_error_break to debug